### PR TITLE
Tailwind plugins and Inital styling

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -4,5 +4,7 @@
   "tabWidth": 2,
   "singleQuote": true,
   "printWidth": 100,
-  "trailingComma": "none"
+  "trailingComma": "none",
+  "plugins": ["prettier-plugin-tailwindcss"]
+  
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@rushstack/eslint-patch": "^1.8.0",
+        "@tailwindcss/forms": "^0.5.9",
         "@typescript-eslint/eslint-plugin": "^8.8.1",
         "@typescript-eslint/parser": "^8.8.1",
         "@vitejs/plugin-vue": "^5.0.5",
@@ -22,7 +23,8 @@
         "eslint": "^8.57.0",
         "eslint-plugin-vue": "^9.23.0",
         "postcss": "^8.4.47",
-        "prettier": "^3.2.5",
+        "prettier": "^3.3.3",
+        "prettier-plugin-tailwindcss": "^0.6.8",
         "tailwindcss": "^3.4.14",
         "typescript": "^5.6.3",
         "vite": "^5.3.1"
@@ -1022,6 +1024,19 @@
       "integrity": "sha512-WJgX9nzTqknM393q1QJDJmoW28kUfEnybeTfVNcNAPnIx210RXm2DiXiHzfNPJNIUUb1tJnz/l4QGtJ30PgWmA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tailwindcss/forms": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.9.tgz",
+      "integrity": "sha512-tM4XVr2+UVTxXJzey9Twx48c1gcxFStqn1pQz0tRsX8o3DvxhN5oY5pvyAbUx7VTaZxpej4Zzvc6h+1RJBzpIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mini-svg-data-uri": "^1.2.3"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20"
+      }
     },
     "node_modules/@types/estree": {
       "version": "1.0.6",
@@ -2917,6 +2932,16 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mini-svg-data-uri": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz",
+      "integrity": "sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mini-svg-data-uri": "cli.js"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -3422,6 +3447,85 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/prettier-plugin-tailwindcss": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.8.tgz",
+      "integrity": "sha512-dGu3kdm7SXPkiW4nzeWKCl3uoImdd5CTZEJGxyypEPL37Wj0HT2pLqjrvSei1nTeuQfO4PUfjeW5cTUNRLZ4sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "peerDependencies": {
+        "@ianvs/prettier-plugin-sort-imports": "*",
+        "@prettier/plugin-pug": "*",
+        "@shopify/prettier-plugin-liquid": "*",
+        "@trivago/prettier-plugin-sort-imports": "*",
+        "@zackad/prettier-plugin-twig-melody": "*",
+        "prettier": "^3.0",
+        "prettier-plugin-astro": "*",
+        "prettier-plugin-css-order": "*",
+        "prettier-plugin-import-sort": "*",
+        "prettier-plugin-jsdoc": "*",
+        "prettier-plugin-marko": "*",
+        "prettier-plugin-multiline-arrays": "*",
+        "prettier-plugin-organize-attributes": "*",
+        "prettier-plugin-organize-imports": "*",
+        "prettier-plugin-sort-imports": "*",
+        "prettier-plugin-style-order": "*",
+        "prettier-plugin-svelte": "*"
+      },
+      "peerDependenciesMeta": {
+        "@ianvs/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@prettier/plugin-pug": {
+          "optional": true
+        },
+        "@shopify/prettier-plugin-liquid": {
+          "optional": true
+        },
+        "@trivago/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@zackad/prettier-plugin-twig-melody": {
+          "optional": true
+        },
+        "prettier-plugin-astro": {
+          "optional": true
+        },
+        "prettier-plugin-css-order": {
+          "optional": true
+        },
+        "prettier-plugin-import-sort": {
+          "optional": true
+        },
+        "prettier-plugin-jsdoc": {
+          "optional": true
+        },
+        "prettier-plugin-marko": {
+          "optional": true
+        },
+        "prettier-plugin-multiline-arrays": {
+          "optional": true
+        },
+        "prettier-plugin-organize-attributes": {
+          "optional": true
+        },
+        "prettier-plugin-organize-imports": {
+          "optional": true
+        },
+        "prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "prettier-plugin-style-order": {
+          "optional": true
+        },
+        "prettier-plugin-svelte": {
+          "optional": true
+        }
       }
     },
     "node_modules/punycode": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "@rushstack/eslint-patch": "^1.8.0",
+    "@tailwindcss/forms": "^0.5.9",
     "@typescript-eslint/eslint-plugin": "^8.8.1",
     "@typescript-eslint/parser": "^8.8.1",
     "@vitejs/plugin-vue": "^5.0.5",
@@ -25,7 +26,8 @@
     "eslint": "^8.57.0",
     "eslint-plugin-vue": "^9.23.0",
     "postcss": "^8.4.47",
-    "prettier": "^3.2.5",
+    "prettier": "^3.3.3",
+    "prettier-plugin-tailwindcss": "^0.6.8",
     "tailwindcss": "^3.4.14",
     "typescript": "^5.6.3",
     "vite": "^5.3.1"

--- a/src/App.vue
+++ b/src/App.vue
@@ -14,6 +14,7 @@ import HelloWorld from './components/HelloWorld.vue'
         <RouterLink to="/">Home</RouterLink>
         <RouterLink to="/about">About</RouterLink>
         <RouterLink to="/list">List</RouterLink>
+        <RouterLink to="/list">Todo</RouterLink>
       </nav>
     </div>
   </header>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -19,6 +19,11 @@ const router = createRouter({
       path: '/list',
       name: 'list',
       component: () => import('../views/ListView.vue')
+    },
+    {
+      path: '/todo',
+      name: 'todo',
+      component: () => import('../views/TodoView.vue')
     }
   ]
 })

--- a/src/views/TodoView.vue
+++ b/src/views/TodoView.vue
@@ -1,0 +1,68 @@
+<template>
+  <div>
+    <h1>To-Do List</h1>
+
+    <div class="my-4 flex flex-row items-center justify-start gap-x-4 rounded-xl bg-white p-2.5">
+      <input
+        class="h-5 w-5 rounded border-0 bg-gray-200 font-semibold text-zinc-800 focus:ring-0 focus:ring-transparent"
+        type="checkbox"
+      />
+      <input
+        class="border-0 bg-transparent p-0 font-semibold text-zinc-800 ring-0 placeholder:font-normal focus:border-0 focus:outline-none focus:ring-0"
+        v-model="newTask"
+        type="text"
+        placeholder="Add a new task"
+        @keyup.enter="addTask"
+      />
+      <button class="" @click="addTask">Add</button>
+    </div>
+
+    <ul class="flex flex-col gap-y-2">
+      <li
+        v-for="(task, index) in tasks"
+        :key="index"
+        class="flex flex-row items-center justify-start gap-x-4 rounded-xl bg-white p-2.5"
+      >
+        <input
+          class="h-5 w-5 rounded border-0 bg-gray-200 text-zinc-800 focus:ring-0 focus:ring-transparent"
+          type="checkbox"
+          v-model="task.completed"
+        />
+        <span
+          class="relative font-semibold text-zinc-800 after:absolute after:left-0 after:top-1/2 after:h-[2px] after:-translate-y-1/2 after:transform after:bg-zinc-800 after:transition-all after:duration-500 after:ease-in-out"
+          :class="task.completed ? 'after:w-full' : 'after:w-0'"
+        >
+          {{ task.text }}
+        </span>
+        <button @click="removeTask(index)">Delete</button>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      newTask: '',
+      tasks: [
+        { text: 'Sample Task 1', completed: false },
+        { text: 'Sample Task 2', completed: true }
+      ]
+    }
+  },
+  methods: {
+    addTask() {
+      if (this.newTask.trim() !== '') {
+        this.tasks.push({ text: this.newTask.trim(), completed: false })
+        this.newTask = ''
+      }
+    },
+    removeTask(index) {
+      this.tasks.splice(index, 1)
+    }
+  }
+}
+</script>
+
+<style scoped></style>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,6 @@
 /** @type {import('tailwindcss').Config} */
+import forms from '@tailwindcss/forms';
+
 export default {
   content: [
     "./index.html",
@@ -7,6 +9,8 @@ export default {
   theme: {
     extend: {},
   },
-  plugins: [],
+  plugins: [
+    forms,
+  ],
 }
 


### PR DESCRIPTION
Introduces two Tailwind plugins—one for Prettier integration and another for form styles—and sets up a new list view page to begin applying styles. 

### Changes:

- Added the Tailwind Prettier plugin to ensure consistent formatting of class-heavy HTML.
- Installed the Tailwind Forms plugin to simplify and standardize form input styling.
- Created a basic list view page, which will serve as a template for applying Tailwind styling in future iterations.